### PR TITLE
Update to Jug 1.6.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "Jug" %}
-{% set version = "1.6.5" %}
-{% set sha256 = "982e18c4b837dd7828e718bb252b4ba78da3e2dfe65d1d92b85e03e9c9e0146a" %}
+{% set version = "1.6.6" %}
+{% set sha256 = "897ffbbbe8061772c238b4f436512ea3696016a04473c45a716d78c0de103ec1" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Just update version number & sha256 value

This is a trivial patch.